### PR TITLE
Add Test Coverage Reports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,4 +66,9 @@ jobs:
         run: mix lint.ci
 
       - name: Run Tests
-        run: mix test
+        run: mix coveralls.json
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Leet Code Practice
 
 [![gh-actions](https://github.com/terenceponce/leetcode/workflows/CI/badge.svg)](https://github.com/terenceponce/leetcode/actions?workflow=CI)
+[![codecov](https://codecov.io/gh/terenceponce/leetcode/graph/badge.svg?token=c4ynvTR4W3)](https://codecov.io/gh/terenceponce/leetcode)
 
 These are my solutions to LeetCode problems written in Elixir.

--- a/coveralls.json
+++ b/coveralls.json
@@ -1,0 +1,5 @@
+{
+  "skip_files": [
+    "test"
+  ]
+}

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,15 @@ defmodule LeetCodePractice.MixProject do
       elixir: "1.15.7",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
-      aliases: aliases()
+      aliases: aliases(),
+      test_coverage: [tool: ExCoveralls],
+      preferred_cli_env: [
+        coveralls: :test,
+        "coveralls.detail": :test,
+        "coveralls.post": :test,
+        "coveralls.html": :test,
+        "coveralls.cobertura": :test
+      ]
     ]
   end
 
@@ -22,7 +30,8 @@ defmodule LeetCodePractice.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:credo, "1.7.0", only: [:dev, :test], runtime: false}
+      {:credo, "1.7.0", only: [:dev, :test], runtime: false},
+      {:excoveralls, "0.18.0", only: :test}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,7 @@
 %{
   "bunt": {:hex, :bunt, "0.2.1", "e2d4792f7bc0ced7583ab54922808919518d0e57ee162901a16a1b6664ef3b14", [:mix], [], "hexpm", "a330bfb4245239787b15005e66ae6845c9cd524a288f0d141c148b02603777a5"},
   "credo": {:hex, :credo, "1.7.0", "6119bee47272e85995598ee04f2ebbed3e947678dee048d10b5feca139435f75", [:mix], [{:bunt, "~> 0.2.1", [hex: :bunt, repo: "hexpm", optional: false]}, {:file_system, "~> 0.2.8", [hex: :file_system, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm", "6839fcf63d1f0d1c0f450abc8564a57c43d644077ab96f2934563e68b8a769d7"},
+  "excoveralls": {:hex, :excoveralls, "0.18.0", "b92497e69465dc51bc37a6422226ee690ab437e4c06877e836f1c18daeb35da9", [:mix], [{:castore, "~> 1.0", [hex: :castore, repo: "hexpm", optional: true]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm", "1109bb911f3cb583401760be49c02cbbd16aed66ea9509fc5479335d284da60b"},
   "file_system": {:hex, :file_system, "0.2.10", "fb082005a9cd1711c05b5248710f8826b02d7d1784e7c3451f9c1231d4fc162d", [:mix], [], "hexpm", "41195edbfb562a593726eda3b3e8b103a309b733ad25f3d642ba49696bf715dc"},
   "jason": {:hex, :jason, "1.4.1", "af1504e35f629ddcdd6addb3513c3853991f694921b1b9368b0bd32beb9f1b63", [:mix], [{:decimal, "~> 1.0 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "fbb01ecdfd565b56261302f7e1fcc27c4fb8f32d56eab74db621fc154604a7a1"},
 }


### PR DESCRIPTION
This adds ExCoveralls as the test coverage reporter.

This also integrates CodeCov.io to submit test coverage reports to.